### PR TITLE
fixed typo Zend\View\Modle\ViewModel in Zend\View\Model\ViewModel

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Documentation;
 
 use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\View\Modle\ViewModel;
+use Zend\View\Model\ViewModel;
 
 return [
     'router' => [


### PR DESCRIPTION
Fixes Error thrown Zend\Mvc\Exception\InvalidArgumentException "The supplied View Model could not be found"